### PR TITLE
Tag container with the job id for which it has been created

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Constants.java
@@ -42,6 +42,7 @@ public interface Constants {
 
     // internal use only
     String CREATED_BY_LABEL_KEY = "Elastic-Agent-Created-By";
+    String JOB_ID_LABEL_KEY = "Elastic-Agent-Job-Id";
     String ENVIRONMENT_LABEL_KEY = "Elastic-Agent-Environment-Name";
     String CONFIGURATION_LABEL_KEY = "Elastic-Agent-Configuration";
     String SWARM_SERVICE_NAME = "com.docker.swarm.service.name";

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerService.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerService.java
@@ -186,6 +186,7 @@ public class DockerService {
         HashMap<String, String> labels = new HashMap<>();
 
         labels.put(CREATED_BY_LABEL_KEY, Constants.PLUGIN_ID);
+        labels.put(JOB_ID_LABEL_KEY, String.valueOf(request.jobIdentifier().getJobId()));
         if (StringUtils.isNotBlank(request.environment())) {
             labels.put(ENVIRONMENT_LABEL_KEY, request.environment());
         }

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
@@ -1,0 +1,111 @@
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.model;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class JobIdentifier {
+    @Expose
+    @SerializedName("pipeline_name")
+    private String pipelineName;
+
+    @Expose
+    @SerializedName("pipeline_counter")
+    private final Long pipelineCounter;
+
+    @Expose
+    @SerializedName("pipeline_label")
+    private final String pipelineLabel;
+
+    @Expose
+    @SerializedName("stage_name")
+    private final String staqeName;
+
+    @Expose
+    @SerializedName("stage_counter")
+    private final String stageCounter;
+
+    @Expose
+    @SerializedName("job_name")
+    private final String jobName;
+
+    @Expose
+    @SerializedName("job_id")
+    private final Long jobId;
+
+    public JobIdentifier() {
+        pipelineCounter = null;
+        pipelineLabel = null;
+        staqeName = null;
+        stageCounter = null;
+        jobName = null;
+        jobId = null;
+    }
+
+    public JobIdentifier(Long jobId) {
+        this(null, null, null, null, null, null, jobId);
+    }
+
+    public JobIdentifier(String pipelineName, Long pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName, Long jobId) {
+        this.pipelineName = pipelineName;
+        this.pipelineCounter = pipelineCounter;
+        this.pipelineLabel = pipelineLabel;
+        this.staqeName = staqeName;
+        this.stageCounter = stageCounter;
+        this.jobName = jobName;
+        this.jobId = jobId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JobIdentifier)) return false;
+
+        JobIdentifier that = (JobIdentifier) o;
+
+        if (pipelineCounter != that.pipelineCounter) return false;
+        if (jobId != that.jobId) return false;
+        if (pipelineName != null ? !pipelineName.equals(that.pipelineName) : that.pipelineName != null) return false;
+        if (pipelineLabel != null ? !pipelineLabel.equals(that.pipelineLabel) : that.pipelineLabel != null)
+            return false;
+        if (staqeName != null ? !staqeName.equals(that.staqeName) : that.staqeName != null) return false;
+        if (stageCounter != null ? !stageCounter.equals(that.stageCounter) : that.stageCounter != null) return false;
+        return jobName != null ? jobName.equals(that.jobName) : that.jobName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pipelineName != null ? pipelineName.hashCode() : 0;
+        result = 31 * result + (int) (pipelineCounter ^ (pipelineCounter >>> 32));
+        result = 31 * result + (pipelineLabel != null ? pipelineLabel.hashCode() : 0);
+        result = 31 * result + (staqeName != null ? staqeName.hashCode() : 0);
+        result = 31 * result + (stageCounter != null ? stageCounter.hashCode() : 0);
+        result = 31 * result + (jobName != null ? jobName.hashCode() : 0);
+        result = 31 * result + (int) (jobId ^ (jobId >>> 32));
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JobIdentifier{" +
+                "pipelineName='" + pipelineName + '\'' +
+                ", pipelineCounter=" + pipelineCounter +
+                ", pipelineLabel='" + pipelineLabel + '\'' +
+                ", staqeName='" + staqeName + '\'' +
+                ", stageCounter='" + stageCounter + '\'' +
+                ", jobName='" + jobName + '\'' +
+                ", jobId=" + jobId +
+                '}';
+    }
+
+    public Long getJobId() {
+        return jobId;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public String representation() {
+        return pipelineName + "/" + pipelineCounter + "/" + staqeName + "/" + stageCounter + "/" + jobName;
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
@@ -10,39 +10,33 @@ public class JobIdentifier {
 
     @Expose
     @SerializedName("pipeline_counter")
-    private final Long pipelineCounter;
+    private Long pipelineCounter;
 
     @Expose
     @SerializedName("pipeline_label")
-    private final String pipelineLabel;
+    private String pipelineLabel;
 
     @Expose
     @SerializedName("stage_name")
-    private final String staqeName;
+    private String staqeName;
 
     @Expose
     @SerializedName("stage_counter")
-    private final String stageCounter;
+    private String stageCounter;
 
     @Expose
     @SerializedName("job_name")
-    private final String jobName;
+    private String jobName;
 
     @Expose
     @SerializedName("job_id")
-    private final Long jobId;
-
-    public JobIdentifier() {
-        pipelineCounter = null;
-        pipelineLabel = null;
-        staqeName = null;
-        stageCounter = null;
-        jobName = null;
-        jobId = null;
-    }
+    private Long jobId;
 
     public JobIdentifier(Long jobId) {
-        this(null, null, null, null, null, null, jobId);
+        this.jobId = jobId;
+    }
+
+    public JobIdentifier() {
     }
 
     public JobIdentifier(String pipelineName, Long pipelineCounter, String pipelineLabel, String staqeName, String stageCounter, String jobName, Long jobId) {

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/CreateAgentRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/CreateAgentRequest.java
@@ -21,6 +21,7 @@ import cd.go.contrib.elasticagents.dockerswarm.elasticagent.Constants;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.RequestExecutor;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors.CreateAgentRequestExecutor;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -39,15 +40,16 @@ public class CreateAgentRequest {
     private String autoRegisterKey;
     private Map<String, String> properties;
     private String environment;
-
+    private JobIdentifier jobIdentifier;
 
     public CreateAgentRequest() {
     }
 
-    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment) {
+    public CreateAgentRequest(String autoRegisterKey, Map<String, String> properties, String environment, JobIdentifier jobIdentifier) {
         this.autoRegisterKey = autoRegisterKey;
         this.properties = properties;
         this.environment = environment;
+        this.jobIdentifier = jobIdentifier;
     }
 
     public String autoRegisterKey() {
@@ -60,6 +62,10 @@ public class CreateAgentRequest {
 
     public String environment() {
         return environment;
+    }
+
+    public JobIdentifier jobIdentifier() {
+        return jobIdentifier;
     }
 
     public static CreateAgentRequest fromJSON(String json) {

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServiceTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServiceTest.java
@@ -63,6 +63,12 @@ public class DockerServiceTest extends BaseTest {
     }
 
     @Test
+    public void shouldCreateServiceForTheJobId() throws Exception {
+        DockerService dockerService = DockerService.create(request, createSettings(), docker);
+        assertThat(dockerService.jobId(), is(String.valueOf(jobIdentifier.getJobId())));
+    }
+
+    @Test
     public void shouldNotCreateServiceIfTheImageIsNotProvided() throws Exception {
         CreateAgentRequest request = new CreateAgentRequest("key", new HashMap<>(), "environment", new JobIdentifier(100L));
 
@@ -207,6 +213,18 @@ public class DockerServiceTest extends BaseTest {
 
         DockerService dockerService = DockerService.fromService(docker.inspectService(service.name()));
 
+        assertEquals(service, dockerService);
+    }
+
+    @Test
+    public void shouldFindAnExistingServiceWithJobIdInformation() throws Exception {
+        DockerService service = DockerService.create(request, createSettings(), docker);
+        services.add(service.name());
+        assertThat(service.jobId(), is(String.valueOf(jobIdentifier.getJobId())));
+
+        DockerService dockerService = DockerService.fromService(docker.inspectService(service.name()));
+
+        assertThat(service.jobId(), is(String.valueOf(jobIdentifier.getJobId())));
         assertEquals(service, dockerService);
     }
 

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServiceTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServiceTest.java
@@ -16,8 +16,11 @@
 
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent;
 
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.CreateAgentRequest;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.spotify.docker.client.messages.Volume;
 import com.spotify.docker.client.messages.mount.Mount;
 import com.spotify.docker.client.messages.swarm.*;
@@ -40,12 +43,16 @@ public class DockerServiceTest extends BaseTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+    private JobIdentifier jobIdentifier;
+    private String environment;
 
     @Before
     public void setUp() throws Exception {
         HashMap<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine:latest");
-        request = new CreateAgentRequest("key", properties, "production");
+        jobIdentifier = new JobIdentifier(100L);
+        environment = "production";
+        request = new CreateAgentRequest("key", properties, environment, jobIdentifier);
     }
 
     @Test
@@ -57,12 +64,27 @@ public class DockerServiceTest extends BaseTest {
 
     @Test
     public void shouldNotCreateServiceIfTheImageIsNotProvided() throws Exception {
-        CreateAgentRequest request = new CreateAgentRequest("key", new HashMap<String, String>(), "production");
+        CreateAgentRequest request = new CreateAgentRequest("key", new HashMap<>(), "environment", new JobIdentifier(100L));
 
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("Must provide `Image` attribute.");
 
         DockerService.create(request, createSettings(), docker);
+    }
+
+    @Test
+    public void shouldStartServiceWithCorrectLabel() throws Exception {
+        DockerService dockerService = DockerService.create(request, createSettings(), docker);
+        services.add(dockerService.name());
+        assertServiceExist(dockerService.name());
+
+        Service serviceInfo = docker.inspectService(dockerService.name());
+        ImmutableMap<String, String> labels = serviceInfo.spec().labels();
+
+        assertThat(labels.get(Constants.JOB_ID_LABEL_KEY), is(String.valueOf(jobIdentifier.getJobId())));
+        assertThat(labels.get(Constants.ENVIRONMENT_LABEL_KEY), is(environment));
+        assertThat(labels.get(Constants.CREATED_BY_LABEL_KEY), is(Constants.PLUGIN_ID));
+        assertThat(labels.get(Constants.CONFIGURATION_LABEL_KEY), is(new Gson().toJson(request.properties())));
     }
 
     @Test
@@ -73,7 +95,7 @@ public class DockerServiceTest extends BaseTest {
 
         PluginSettings settings = createSettings();
         settings.setEnvironmentVariables("GLOBAL=something");
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), settings, docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), settings, docker);
         services.add(service.name());
 
         Service serviceInfo = docker.inspectService(service.name());
@@ -89,7 +111,7 @@ public class DockerServiceTest extends BaseTest {
         Map<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine:latest");
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
         Service serviceInfo = docker.inspectService(service.name());
         assertThat(serviceInfo.spec().taskTemplate().containerSpec().env(), hasItem("GO_EA_AUTO_REGISTER_KEY=key"));
@@ -105,7 +127,7 @@ public class DockerServiceTest extends BaseTest {
         List<String> command = Arrays.asList("/bin/sh", "-c", "cat /etc/hosts /etc/group");
         properties.put("Command", StringUtils.join(command, "\n"));
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
         Service serviceInfo = docker.inspectService(service.name());
 
@@ -119,7 +141,7 @@ public class DockerServiceTest extends BaseTest {
         properties.put("MaxMemory", "512MB");
         properties.put("ReservedMemory", "100MB");
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
         Service serviceInfo = docker.inspectService(service.name());
         assertThat(serviceInfo.spec().taskTemplate().resources().limits().memoryBytes(), is(512 * 1024 * 1024L));
@@ -134,7 +156,7 @@ public class DockerServiceTest extends BaseTest {
         properties.put("Image", "alpine:latest");
         properties.put("Hosts", "127.0.0.1 foo bar\n 127.0.0.2 baz");
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
 
         final Service inspectServiceInfo = docker.inspectService(service.name());
@@ -158,7 +180,7 @@ public class DockerServiceTest extends BaseTest {
         properties.put("Image", "alpine:latest");
         properties.put("Mounts", "source=" + volumeName + ", target=/path/in/container");
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
 
         final Service inspectServiceInfo = docker.inspectService(service.name());
@@ -206,7 +228,7 @@ public class DockerServiceTest extends BaseTest {
         properties.put("Secrets", "src=" + secretName);
         properties.put("Command", StringUtils.join(command, "\n"));
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
 
         final Service inspectService = docker.inspectService(service.name());
@@ -224,7 +246,7 @@ public class DockerServiceTest extends BaseTest {
         properties.put("Image", "alpine:latest");
         properties.put("Constraints", format("node.id == %s", nodeId));
 
-        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod"), createSettings(), docker);
+        DockerService service = DockerService.create(new CreateAgentRequest("key", properties, "prod", new JobIdentifier(100L)), createSettings(), docker);
         services.add(service.name());
 
         final Service inspectService = docker.inspectService(service.name());

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServicesTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerServicesTest.java
@@ -16,6 +16,7 @@
 
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent;
 
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.CreateAgentRequest;
 import org.joda.time.Period;
 import org.junit.Before;
@@ -34,12 +35,14 @@ public class DockerServicesTest extends BaseTest {
     private CreateAgentRequest request;
     private DockerServices dockerServices;
     private PluginSettings settings;
+    private JobIdentifier jobIdentifier;
 
     @Before
     public void setUp() throws Exception {
+        jobIdentifier = new JobIdentifier(100L);
         HashMap<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine:latest");
-        request = new CreateAgentRequest("key", properties, "production");
+        request = new CreateAgentRequest("key", properties, "production", jobIdentifier);
         dockerServices = new DockerServices();
         settings = createSettings();
     }

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ServerPingRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ServerPingRequestExecutorTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
 
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.*;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.CreateAgentRequest;
 import org.joda.time.Period;
 import org.junit.Test;
@@ -82,7 +83,7 @@ public class ServerPingRequestExecutorTest extends BaseTest {
         agentInstances.clock = new Clock.TestClock().forward(Period.minutes(11));
         Map<String, String> properties = new HashMap<>();
         properties.put("Image", "alpine:latest");
-        DockerService dockerService = agentInstances.create(new CreateAgentRequest(null, properties, null), createSettings());
+        DockerService dockerService = agentInstances.create(new CreateAgentRequest(null, properties, null, new JobIdentifier(100L)), createSettings());
         services.add(dockerService.name());
 
         ServerPingRequestExecutor serverPingRequestExecutor = new ServerPingRequestExecutor(agentInstances, pluginRequest);

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -20,6 +20,7 @@ import cd.go.contrib.elasticagents.dockerswarm.elasticagent.Agent;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.BaseTest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerService;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerServices;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.CreateAgentRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.ShouldAssignWorkRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
@@ -45,7 +46,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
         agentInstances = new DockerServices();
         properties.put("foo", "bar");
         properties.put("Image", "alpine:latest");
-        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment), createSettings());
+        instance = agentInstances.create(new CreateAgentRequest(UUID.randomUUID().toString(), properties, environment, new JobIdentifier(100L)), createSettings());
         services.add(instance.name());
     }
 


### PR DESCRIPTION
* As part of create-agent request, server sends the job-identifier information in request body. Use the provided job-identifier information to label the newly created elastic agent with the job information for which it has been created
* Add a job_id label on the docker service