### PR TITLE
UI improvements in plugin and agent status report (#51)

### DIFF
--- a/src/main/resources/agent-status-report.template.ftlh
+++ b/src/main/resources/agent-status-report.template.ftlh
@@ -129,15 +129,23 @@
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] table {
+		width:           100%;
+		margin-top:      10px;
 		text-align:      left;
 		border-spacing:  0;
 		border-collapse: collapse;
 	}
 
+	[data-plugin-style-id="docker-swarm-plugin"] table thead {
+		background: #b9f6ca;
+	}
+
+	[data-plugin-style-id="docker-swarm-plugin"] table tr {
+		border: 1px solid #ddd;
+	}
+
 	[data-plugin-style-id="docker-swarm-plugin"] table thead tr th {
-		font-weight:   600;
-		border-bottom: 2px solid #ddd;
-		border-top:    1px solid #ddd;
+		font-weight: 600;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] no-padding-left {
@@ -163,7 +171,7 @@
 		display:          inline-block;
 		width:            10px;
 		height:           10px;
-		margin-top:       6px;
+		margin-top:       4px;
 		margin-right:     5px;
 		background-color: #FFEB3B;
 		border-radius:    100%;
@@ -282,7 +290,7 @@
 					</ul>
 					<br/><br/>
 					<h4>Tasks status</h4>
-					<table style="margin: 5px;">
+					<table>
 						<thead>
 						<tr>
 							<th>Task ID</th>

--- a/src/main/resources/status-report.template.ftlh
+++ b/src/main/resources/status-report.template.ftlh
@@ -39,19 +39,18 @@
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .node-content {
-		padding: 10px;
+		padding: 25px;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .node table {
-		width:     calc(100% - 40px);
-		min-width: 95%;
+		width:     100%;
 		border:    1px solid #D8D8D8;
+		margin:    10px 0px 0px 0px;
 		font-size: 13px;
-		margin:    10px 20px 20px 20px;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .node table thead {
-		background: #D8D8D8;
+		background: #b9f6ca;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .node table thead th {
@@ -100,9 +99,7 @@
 	[data-plugin-style-id="docker-swarm-plugin"] dt {
 		float:       left;
 		clear:       both;
-		min-width:   150px;
-		text-align:  right;
-		font-weight: normal;
+		font-weight: 600;
 		padding:     5px 0px;
 		margin:      0;
 	}
@@ -158,14 +155,14 @@
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] dd {
-		float:       left;
-		padding:     5px 0px;
-		font-weight: 600;
-		margin:      0;
+		float:        left;
+		padding:      5px 0px;
+		font-weight:  normal;
+		margin-right: 50px;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .node .header {
-		margin: 20px 0px 0px 20px;
+		margin: 20px 0px 0px 0px;
 	}
 
 	[data-plugin-style-id="docker-swarm-plugin"] .warning {
@@ -270,7 +267,7 @@
                                 </#list>
                             <#else>
                             <tr>
-								<td colspan="5" class="message">No running tasks.</td>
+								<td colspan="6" class="message">No running tasks.</td>
 							</tr>
                             </#if>
 						</tbody>


### PR DESCRIPTION
This PR is to make UI consistent across all the plugin/agent status reports.

### Screenshots

#### Plugin status report
<img width="1440" alt="screen shot 2018-02-23 at 8 57 26 pm" src="https://user-images.githubusercontent.com/7871209/36601929-88d869c4-18dc-11e8-9f67-502cb5777df2.png">

#### Agent status report
<img width="1439" alt="screen shot 2018-02-23 at 8 57 01 pm" src="https://user-images.githubusercontent.com/7871209/36601946-91ccf874-18dc-11e8-9cf3-95a2ab9a6314.png">
