### PR TITLE
Fixed issue in JobIdentifier's hashcode method.

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerPlugin.java
@@ -70,11 +70,9 @@ public class DockerPlugin implements GoPlugin {
                 case REQUEST_GET_CAPABILITIES:
                     return new GetCapabilitiesExecutor().execute();
                 case REQUEST_STATUS_REPORT:
-                    refreshInstances();
-                    return new StatusReportExecutor(pluginRequest).execute();
+                    return new StatusReportExecutor(pluginRequest, agentInstances).execute();
                 case REQUEST_ELASTIC_AGENT_STATUS_REPORT:
-                    refreshInstances();
-                    return AgentStatusReportRequest.fromJSON(request.requestBody()).executor(pluginRequest).execute();
+                    return AgentStatusReportRequest.fromJSON(request.requestBody()).executor(pluginRequest, agentInstances).execute();
                 default:
                     throw new UnhandledRequestTypeException(request.requestName());
             }

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutor.java
@@ -45,12 +45,12 @@ public class ShouldAssignWorkRequestExecutor implements RequestExecutor {
             return DefaultGoPluginApiResponse.success("false");
         }
 
-        if (request.jobIdentifier() != null && request.jobIdentifier().equals(instance.jobIdentifier())) {
+        if (request.jobIdentifier() != null && request.jobIdentifier().getJobId().equals(instance.jobIdentifier().getJobId())) {
             LOG.info(format("[should-assign-work] Job with identifier {0} can be assigned to an agent {1}.", request.jobIdentifier(), instance.name()));
             return DefaultGoPluginApiResponse.success("true");
         }
 
-        LOG.info(format("[should-assign-work] Job with profile {0} can be assigned to an agent {1}", request.properties(), instance.name()));
+        LOG.info(format("[should-assign-work] Job with identifier {0} can not be assigned to an agent {1}.", request.jobIdentifier(), instance.name()));
         return DefaultGoPluginApiResponse.success("false");
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/StatusReportExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/StatusReportExecutor.java
@@ -16,7 +16,9 @@
 
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
 
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.AgentInstances;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerClientFactory;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerService;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.builders.PluginStatusReportViewBuilder;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.reports.SwarmCluster;
@@ -33,23 +35,25 @@ import static cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerPlugin.
 
 public class StatusReportExecutor {
     private final PluginRequest pluginRequest;
+    private final AgentInstances<DockerService> agentInstances;
     private final DockerClientFactory dockerClientFactory;
     private final PluginStatusReportViewBuilder statusReportViewBuilder;
 
-    public StatusReportExecutor(PluginRequest pluginRequest) throws IOException {
-        this(pluginRequest, DockerClientFactory.instance(), PluginStatusReportViewBuilder.instance());
+    public StatusReportExecutor(PluginRequest pluginRequest, AgentInstances<DockerService> agentInstances) throws IOException {
+        this(pluginRequest, agentInstances, DockerClientFactory.instance(), PluginStatusReportViewBuilder.instance());
     }
 
-    StatusReportExecutor(PluginRequest pluginRequest, DockerClientFactory dockerClientFactory, PluginStatusReportViewBuilder statusReportViewBuilder) {
+    StatusReportExecutor(PluginRequest pluginRequest, AgentInstances<DockerService> agentInstances, DockerClientFactory dockerClientFactory, PluginStatusReportViewBuilder statusReportViewBuilder) {
         this.pluginRequest = pluginRequest;
+        this.agentInstances = agentInstances;
         this.dockerClientFactory = dockerClientFactory;
         this.statusReportViewBuilder = statusReportViewBuilder;
     }
 
     public GoPluginApiResponse execute() {
         try {
-            LOG.info("[status-report] Generating status report");
-
+            LOG.debug("[status-report] Generating status report.");
+            agentInstances.refreshAll(pluginRequest);
             final DockerClient dockerClient = dockerClientFactory.docker(pluginRequest.getPluginSettings());
             final SwarmCluster swarmCluster = new SwarmCluster(dockerClient);
             final Template template = statusReportViewBuilder.getTemplate("status-report.template.ftlh");

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifier.java
@@ -2,11 +2,9 @@ package cd.go.contrib.elasticagents.dockerswarm.elasticagent.model;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import org.apache.commons.lang.StringUtils;
 
 import static cd.go.contrib.elasticagents.dockerswarm.elasticagent.utils.Util.GSON;
-import static java.text.MessageFormat.format;
-
+import static java.lang.String.format;
 public class JobIdentifier {
     @Expose
     @SerializedName("pipeline_name")
@@ -35,8 +33,6 @@ public class JobIdentifier {
     @Expose
     @SerializedName("job_id")
     private Long jobId;
-
-    private String representation;
 
     public JobIdentifier(Long jobId) {
         this.jobId = jobId;
@@ -84,10 +80,23 @@ public class JobIdentifier {
     }
 
     public String getRepresentation() {
-        if (StringUtils.isBlank(representation)) {
-            this.representation = format("{0}/{1}/{2}/{3}/{4}", pipelineName, pipelineCounter, stageName, stageCounter, jobName);
-        }
-        return representation;
+        return format("%s/%s/%s/%s/%s", pipelineName, pipelineCounter, stageName, stageCounter, jobName);
+    }
+
+    public String getPipelineHistoryPageLink() {
+        return format("/go/tab/pipeline/history/%s", pipelineName);
+    }
+
+    public String getVsmPageLink() {
+        return format("/go/pipelines/value_stream_map/%s/%s", pipelineName, pipelineCounter);
+    }
+
+    public String getStageDetailsPageLink() {
+        return format("/go/pipelines/%s/%s/%s/%s", pipelineName, pipelineCounter, stageName, stageCounter);
+    }
+
+    public String getJobDetailsPageLink() {
+        return format("/go/tab/build/detail/%s", getRepresentation());
     }
 
     @Override
@@ -97,25 +106,26 @@ public class JobIdentifier {
 
         JobIdentifier that = (JobIdentifier) o;
 
-        if (pipelineCounter != that.pipelineCounter) return false;
-        if (jobId != that.jobId) return false;
         if (pipelineName != null ? !pipelineName.equals(that.pipelineName) : that.pipelineName != null) return false;
+        if (pipelineCounter != null ? !pipelineCounter.equals(that.pipelineCounter) : that.pipelineCounter != null)
+            return false;
         if (pipelineLabel != null ? !pipelineLabel.equals(that.pipelineLabel) : that.pipelineLabel != null)
             return false;
         if (stageName != null ? !stageName.equals(that.stageName) : that.stageName != null) return false;
         if (stageCounter != null ? !stageCounter.equals(that.stageCounter) : that.stageCounter != null) return false;
-        return jobName != null ? jobName.equals(that.jobName) : that.jobName == null;
+        if (jobName != null ? !jobName.equals(that.jobName) : that.jobName != null) return false;
+        return jobId != null ? jobId.equals(that.jobId) : that.jobId == null;
     }
 
     @Override
     public int hashCode() {
         int result = pipelineName != null ? pipelineName.hashCode() : 0;
-        result = 31 * result + (int) (pipelineCounter ^ (pipelineCounter >>> 32));
+        result = 31 * result + (pipelineCounter != null ? pipelineCounter.hashCode() : 0);
         result = 31 * result + (pipelineLabel != null ? pipelineLabel.hashCode() : 0);
         result = 31 * result + (stageName != null ? stageName.hashCode() : 0);
         result = 31 * result + (stageCounter != null ? stageCounter.hashCode() : 0);
         result = 31 * result + (jobName != null ? jobName.hashCode() : 0);
-        result = 31 * result + (int) (jobId ^ (jobId >>> 32));
+        result = 31 * result + (jobId != null ? jobId.hashCode() : 0);
         return result;
     }
 
@@ -125,7 +135,7 @@ public class JobIdentifier {
                 "pipelineName='" + pipelineName + '\'' +
                 ", pipelineCounter=" + pipelineCounter +
                 ", pipelineLabel='" + pipelineLabel + '\'' +
-                ", staqeName='" + stageName + '\'' +
+                ", stageName='" + stageName + '\'' +
                 ", stageCounter='" + stageCounter + '\'' +
                 ", jobName='" + jobName + '\'' +
                 ", jobId=" + jobId +

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationErrorHandler.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationErrorHandler.java
@@ -23,12 +23,14 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import freemarker.template.Template;
 
+import static cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerPlugin.LOG;
 import static java.text.MessageFormat.format;
 
 public class StatusReportGenerationErrorHandler {
 
     public static GoPluginApiResponse handle(PluginStatusReportViewBuilder builder, Exception e) {
         try {
+            LOG.error(format("Error while generating status report: {0}", e.getMessage()), e);
             final Template template = builder.getTemplate("error.template.ftlh");
             final String errorView = builder.build(template, new StatusReportGenerationError(e));
 
@@ -37,7 +39,8 @@ public class StatusReportGenerationErrorHandler {
 
             return DefaultGoPluginApiResponse.success(responseJSON.toString());
         } catch (Exception ex) {
-            return DefaultGoPluginApiResponse.error(format("Error while generating status report: {0}.", e.toString()));
+            LOG.error(format("Failed to generate error report: {0}", e.getMessage()), e);
+            return DefaultGoPluginApiResponse.error(format("Failed to generate error report: {0}.", e.toString()));
         }
     }
 

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationException.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationException.java
@@ -16,9 +16,14 @@
 
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.reports;
 
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
+
+import static java.lang.String.format;
+
 public class StatusReportGenerationException extends RuntimeException {
     private final String message;
     private final String detailedMessage;
+    private static final String MISSING_SERVICE = "Can not find a running service for the provided %s '%s'";
 
     public StatusReportGenerationException(String message) {
         this(message, null);
@@ -35,5 +40,13 @@ public class StatusReportGenerationException extends RuntimeException {
 
     public String getDetailedMessage() {
         return detailedMessage;
+    }
+
+    public static StatusReportGenerationException noRunningService(JobIdentifier jobIdentifier) {
+        return new StatusReportGenerationException("Service is not running.", format(MISSING_SERVICE, "job identifier", jobIdentifier.getRepresentation()));
+    }
+
+    public static StatusReportGenerationException noRunningService(String elasticAgentId) {
+        return new StatusReportGenerationException("Service is not running.", format(MISSING_SERVICE, "elastic agent id", elasticAgentId));
     }
 }

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/AgentStatusReportRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/AgentStatusReportRequest.java
@@ -1,5 +1,7 @@
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests;
 
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.AgentInstances;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerService;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors.AgentStatusReportExecutor;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
@@ -38,7 +40,7 @@ public class AgentStatusReportRequest {
         return jobIdentifier;
     }
 
-    public AgentStatusReportExecutor executor(PluginRequest pluginRequest) throws IOException {
-        return new AgentStatusReportExecutor(this, pluginRequest);
+    public AgentStatusReportExecutor executor(PluginRequest pluginRequest, AgentInstances<DockerService> agentInstances) throws IOException {
+        return new AgentStatusReportExecutor(this, pluginRequest, agentInstances);
     }
 }

--- a/src/main/resources/agent-status-report.template.ftlh
+++ b/src/main/resources/agent-status-report.template.ftlh
@@ -193,31 +193,29 @@
 		<ul class="entity_title">
 			<li class="name">
 				<span class="label">Pipeline</span>
-				<a href="/go/tab/pipeline/history/${jobIdentifier.pipelineName!''}"
+				<a href="${jobIdentifier.pipelineHistoryPageLink!''}"
 				   title="View this pipeline's activity"
 				   rel="nofollow noreferrer" target="_blank">${jobIdentifier.pipelineName!''}</a>
 			</li>
 			<li class="pipeline_label">
 				<span class="label">Instance</span>
 				<span class="run_no">${jobIdentifier.pipelineCounter!''}</span>
-				<a href="/go/pipelines/value_stream_map/${jobIdentifier.pipelineName!''}/${jobIdentifier.pipelineCounter!''}"
+				<a href="${jobIdentifier.vsmPageLink!''}"
 				   title="View this stage's jobs summary"
 				   rel="nofollow noreferrer" target="_blank">VSM</a>
 			</li>
 			<li class="stage_name">
 				<span class="label">Stage</span>
-				<a
-					href="/go/pipelines/${jobIdentifier.pipelineName!''}/${jobIdentifier.pipelineCounter!''}/${jobIdentifier.stageName!''}/${jobIdentifier.stageCounter!''}"
-					title="View this stage's details"
-					rel="nofollow noreferrer" target="_blank">${jobIdentifier.stageName!''}
-					/ ${jobIdentifier.stageCounter!''}</a>
+				<a href="${jobIdentifier.stageDetailsPageLink!''}"
+				   title="View this stage's details"
+				   rel="nofollow noreferrer"
+				   target="_blank">${jobIdentifier.stageName!''}/ ${jobIdentifier.stageCounter!''}</a>
 			</li>
 			<li class="job_label">
 				<span class="label">Job</span>
-				<a
-					href="/go/tab/build/detail/${jobIdentifier.representation!''}"
-					title="View this job's details"
-					rel="nofollow noreferrer" target="_blank">${jobIdentifier.jobName!''}</a>
+				<a href="${jobIdentifier.jobDetailsPageLink!''}"
+				   title="View this job's details"
+				   rel="nofollow noreferrer" target="_blank">${jobIdentifier.jobName!''}</a>
 			</li>
 
 			<li class="last">

--- a/src/main/resources/error.template.ftlh
+++ b/src/main/resources/error.template.ftlh
@@ -12,52 +12,30 @@
 
 	[data-plugin-style-id="ea-plugin"] .error-container {
 		width:         100%;
-		border:        1px solid #eee;
 		display:       table;
 		margin:        15px 0px;
 		table-layout:  fixed;
 		border-radius: 3px;
 	}
 
-	[data-plugin-style-id="ea-plugin"] .title {
-		padding:        1rem;
-		overflow:       hidden;
-		font-size:      15px;
-		background:     #d1c4e9;
-		font-weight:    600;
-		vertical-align: middle;
-		margin:         -1px -1px 0px -1px;
-		border-radius:  3px 3px 0px 0px;
-	}
-
-	[data-plugin-style-id="ea-plugin"] .stacktrace {
-		height: calc(100vh - 210px);
-		margin: 0px -1px;
-	}
-
-	[data-plugin-style-id="ea-plugin"] .no-stacktrace {
-		color:       #777;
+	[data-plugin-style-id="ea-plugin"] blockquote {
+		color:       #555;
+		border:      1px dashed #ddd;
 		padding:     10px;
+		font-size:   13px;
+		border-left: 4px solid red;
+		margin-top:  10px;
+		font-weight: normal;
+	}
+
+	[data-plugin-style-id="ea-plugin"] blockquote header {
+		color:       #a94442;
 		font-size:   15px;
-		font-weight: 400;
-		background:  #FAFAFA;
+		font-weight: 600;
 	}
 
-	[data-plugin-style-id="ea-plugin"] textarea[readonly="readonly"], textarea[readonly] {
-		cursor:        auto;
-		margin-bottom: 0px;
-	}
-
-	[data-plugin-style-id="ea-plugin"] .logs {
-		color:            white;
-		display:          block;
-		height:           calc(100vh - 210px);
-		font-size:        13px;
-		max-height:       100%;
-		font-weight:      400;
-		font-family:      monaco;
-		padding-left:     10px;
-		background-color: #383838;
+	[data-plugin-style-id="ea-plugin"] blockquote p {
+		margin-top: 10px;
 	}
 </style>
 
@@ -65,18 +43,10 @@
 	<div class="outer-container">
 		<div class="container">
 			<div class="error-container">
-				<div class="title">
-					Error while generating status report: ${ message! }
-				</div>
-				<#if stacktrace??>
-					<div class="stacktrace">
-						<textarea class="logs" readonly>${stacktrace!}</textarea>
-					</div>
-                <#else>
-					<div class="no-stacktrace">
-						Stacktrace not available.
-					</div>
-                </#if>
+				<blockquote>
+					<header>${ message!'' }</header>
+					<p>${description!''}</p>
+				</blockquote>
 			</div>
 		</div>
 	</div>

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/AgentStatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/AgentStatusReportExecutorTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
 
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerClientFactory;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerServices;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginSettings;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.builders.PluginStatusReportViewBuilder;
@@ -64,13 +65,15 @@ public class AgentStatusReportExecutorTest {
     private DockerClient client;
     @Mock
     private PluginSettings pluginSettings;
+    @Mock
+    private DockerServices dockerServices;
 
     private AgentStatusReportExecutor executor;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        executor = new AgentStatusReportExecutor(statusReportRequest, pluginRequest, dockerClientFactory, PluginStatusReportViewBuilder.instance());
+        executor = new AgentStatusReportExecutor(statusReportRequest, pluginRequest, dockerServices, dockerClientFactory, PluginStatusReportViewBuilder.instance());
         when(dockerClientFactory.docker(pluginSettings)).thenReturn(client);
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
     }
@@ -186,7 +189,6 @@ public class AgentStatusReportExecutorTest {
 
         return new StubbedService(serviceId, serviceSpec);
     }
-
 
     class StubbedLogStream implements LogStream {
         private final String logs;

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/ShouldAssignWorkRequestExecutorTest.java
@@ -44,7 +44,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
 
     @Before
     public void setUp() throws Exception {
-        jobIdentifier = new JobIdentifier(100L);
+        jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
         agentInstances = new DockerServices();
         properties.put("foo", "bar");
         properties.put("Image", "alpine:latest");
@@ -62,7 +62,7 @@ public class ShouldAssignWorkRequestExecutorTest extends BaseTest {
 
     @Test
     public void shouldNotAssignWorkToContainerWithNotMatchingJobId() {
-        JobIdentifier mismatchingJobIdentifier = new JobIdentifier(200L);
+        JobIdentifier mismatchingJobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 999999L);;
         ShouldAssignWorkRequest request = new ShouldAssignWorkRequest(new Agent(instance.name(), null, null, null), "FooEnv", properties, mismatchingJobIdentifier);
         GoPluginApiResponse response = new ShouldAssignWorkRequestExecutor(request, agentInstances).execute();
         assertThat(response.responseCode(), is(200));

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/StatusReportExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/StatusReportExecutorTest.java
@@ -17,6 +17,7 @@
 package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
 
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerClientFactory;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerServices;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginSettings;
 import cd.go.contrib.elasticagents.dockerswarm.elasticagent.builders.PluginStatusReportViewBuilder;
@@ -40,6 +41,7 @@ public class StatusReportExecutorTest {
     private PluginRequest pluginRequest;
     private PluginSettings pluginSettings;
     private DockerClient dockerClient;
+    private DockerServices dockerServices;
 
     @Before
     public void setUp() throws Exception {
@@ -47,6 +49,7 @@ public class StatusReportExecutorTest {
         pluginRequest = mock(PluginRequest.class);
         pluginSettings = mock(PluginSettings.class);
         dockerClient = mock(DockerClient.class);
+        dockerServices = mock(DockerServices.class);
 
         when(pluginRequest.getPluginSettings()).thenReturn(pluginSettings);
         when(dockerClientFactory.docker(pluginSettings)).thenReturn(dockerClient);
@@ -60,7 +63,7 @@ public class StatusReportExecutorTest {
         when(builder.getTemplate("status-report.template.ftlh")).thenReturn(template);
         when(builder.build(eq(template), any(SwarmCluster.class))).thenReturn("status-report");
 
-        final GoPluginApiResponse response = new StatusReportExecutor(pluginRequest, dockerClientFactory, builder).execute();
+        final GoPluginApiResponse response = new StatusReportExecutor(pluginRequest, dockerServices, dockerClientFactory, builder).execute();
 
         assertThat(response.responseCode(), is(200));
         assertThat(response.responseBody(), is("{\"view\":\"status-report\"}"));

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifierTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/model/JobIdentifierTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class JobIdentifierTest {
+    @Test
+    public void shouldMatchJobIdentifier() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        final JobIdentifier deserializedJobIdentifier = JobIdentifier.fromJson(jobIdentifier.toJson());
+
+        assertTrue(jobIdentifier.equals(deserializedJobIdentifier));
+    }
+
+    @Test
+    public void shouldCreateRepresentationFromJobIdentifier() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        assertThat(jobIdentifier.getRepresentation(), is("up42/98765/stage_1/30000/job_1"));
+    }
+
+    @Test
+    public void shouldCreatePipelineHistoryPageLink() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        assertThat(jobIdentifier.getPipelineHistoryPageLink(), is("/go/tab/pipeline/history/up42"));
+    }
+
+    @Test
+    public void shouldCreateVSMPageLink() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        assertThat(jobIdentifier.getVsmPageLink(), is("/go/pipelines/value_stream_map/up42/98765"));
+    }
+
+    @Test
+    public void shouldCreateStageDetailsPageLink() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        assertThat(jobIdentifier.getStageDetailsPageLink(), is("/go/pipelines/up42/98765/stage_1/30000"));
+    }
+
+    @Test
+    public void shouldCreateJobDetailsPageLink() {
+        final JobIdentifier jobIdentifier = new JobIdentifier("up42", 98765L, "foo", "stage_1", "30000", "job_1", 876578L);
+
+        assertThat(jobIdentifier.getJobDetailsPageLink(), is("/go/tab/build/detail/up42/98765/stage_1/30000/job_1"));
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationErrorHandlerTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/reports/StatusReportGenerationErrorHandlerTest.java
@@ -26,10 +26,9 @@ import static org.junit.Assert.assertThat;
 public class StatusReportGenerationErrorHandlerTest {
     @Test
     public void shouldConvertThrowableToStatusReportGenerationErrorObject() {
-        final StatusReportGenerationError statusReportGenerationError = new StatusReportGenerationError(new RuntimeException("Some error."));
+        final StatusReportGenerationError statusReportGenerationError = new StatusReportGenerationError(StatusReportGenerationException.noRunningService("foo"));
 
-        assertThat(statusReportGenerationError.getMessage(), is("Some error."));
-        assertThat(statusReportGenerationError.getStacktrace(), startsWith("java.lang.RuntimeException: Some error.\n" +
-                "\tat cd.go.contrib.elasticagents.dockerswarm.elasticagent.reports.StatusReportGenerationErrorHandlerTest.shouldConvertThrowableToStatusReportGenerationErrorObject"));
+        assertThat(statusReportGenerationError.getMessage(), is("Service is not running."));
+        assertThat(statusReportGenerationError.getDescription(), startsWith("Can not find a running service for the provided elastic agent id 'foo'"));
     }
 }


### PR DESCRIPTION
- Agent status report page use's link given by `JobIdentifier`. In earlier implementation template was generating pipeline history, VSM, stage details and job details  page link based on job identifier
- Minor improvement on agent and plugin status report page.
- Sync running docker services using refreshInstances within status report executors. This is to handle any error while syncing services.