### PR TITLE
Bump up Elastic Agent Extension version to 4.0

### DIFF
--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Agent.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Agent.java
@@ -83,6 +83,10 @@ public class Agent {
         return agentId;
     }
 
+    public void elasticAgentId(String agentId) {
+        this.agentId = agentId;
+    }
+
     public AgentState agentState() {
         return agentState;
     }

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Constants.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Constants.java
@@ -29,7 +29,7 @@ public interface Constants {
 
     // The extension point API version that this plugin understands
     String PROCESSOR_API_VERSION = "1.0";
-    String EXTENSION_API_VERSION = "3.0";
+    String EXTENSION_API_VERSION = "4.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(EXTENSION_API_VERSION));

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerPlugin.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/DockerPlugin.java
@@ -69,6 +69,9 @@ public class DockerPlugin implements GoPlugin {
                     return ValidatePluginSettingsRequest.fromJSON(request.requestBody()).executor().execute();
                 case REQUEST_GET_CAPABILITIES:
                     return new GetCapabilitiesExecutor().execute();
+                case REQUEST_JOB_COMPLETION:
+                    refreshInstances();
+                    return JobCompletionRequest.fromJSON(request.requestBody()).executor(agentInstances, pluginRequest).execute();
                 case REQUEST_STATUS_REPORT:
                     return new StatusReportExecutor(pluginRequest, agentInstances).execute();
                 case REQUEST_ELASTIC_AGENT_STATUS_REPORT:

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Request.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/Request.java
@@ -36,7 +36,9 @@ public enum Request {
 
     REQUEST_STATUS_REPORT(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".status-report"),
     REQUEST_ELASTIC_AGENT_STATUS_REPORT(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".agent-status-report"),
-    REQUEST_GET_CAPABILITIES(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-capabilities");
+    REQUEST_GET_CAPABILITIES(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".get-capabilities"),
+
+    REQUEST_JOB_COMPLETION(Constants.ELASTIC_AGENT_REQUEST_PREFIX + ".job-completion");
 
     private final String requestName;
 

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/JobCompletionRequestExecutor.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/JobCompletionRequestExecutor.java
@@ -1,0 +1,43 @@
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
+
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.*;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.JobCompletionRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerPlugin.LOG;
+import static java.text.MessageFormat.format;
+
+public class JobCompletionRequestExecutor implements RequestExecutor {
+    private final JobCompletionRequest jobCompletionRequest;
+    private final AgentInstances<DockerService> agentInstances;
+    private final PluginRequest pluginRequest;
+
+    public JobCompletionRequestExecutor(JobCompletionRequest jobCompletionRequest, AgentInstances<DockerService> agentInstances, PluginRequest pluginRequest) {
+        this.jobCompletionRequest = jobCompletionRequest;
+        this.agentInstances = agentInstances;
+        this.pluginRequest = pluginRequest;
+    }
+
+    @Override
+    public GoPluginApiResponse execute() throws Exception {
+        PluginSettings pluginSettings = pluginRequest.getPluginSettings();
+
+        String elasticAgentId = jobCompletionRequest.getElasticAgentId();
+
+        Agent agent = new Agent();
+        agent.elasticAgentId(elasticAgentId);
+
+        LOG.info(format("[Job Completion] Terminating elastic agent with id {0} on job completion {1}.", agent.elasticAgentId(), jobCompletionRequest.jobIdentifier()));
+
+        List<Agent> agents = Arrays.asList(agent);
+        pluginRequest.disableAgents(agents);
+        agentInstances.terminate(agent.elasticAgentId(), pluginSettings);
+        pluginRequest.deleteAgents(agents);
+
+        return DefaultGoPluginApiResponse.success("");
+    }
+}

--- a/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/JobCompletionRequest.java
+++ b/src/main/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/JobCompletionRequest.java
@@ -1,0 +1,54 @@
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests;
+
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.AgentInstances;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.DockerService;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.PluginRequest;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.RequestExecutor;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors.JobCompletionRequestExecutor;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+import static cd.go.contrib.elasticagents.dockerswarm.elasticagent.utils.Util.GSON;
+
+public class JobCompletionRequest {
+    @Expose
+    @SerializedName("elastic_agent_id")
+    private String elasticAgentId;
+    @Expose
+    @SerializedName("job_identifier")
+    private JobIdentifier jobIdentifier;
+
+    public JobCompletionRequest() {
+    }
+
+    public JobCompletionRequest(String elasticAgentId, JobIdentifier jobIdentifier) {
+        this.elasticAgentId = elasticAgentId;
+        this.jobIdentifier = jobIdentifier;
+    }
+
+    public static JobCompletionRequest fromJSON(String json) {
+        JobCompletionRequest jobCompletionRequest = GSON.fromJson(json, JobCompletionRequest.class);
+        return jobCompletionRequest;
+    }
+
+    public String getElasticAgentId() {
+        return elasticAgentId;
+    }
+
+    public JobIdentifier jobIdentifier() {
+        return jobIdentifier;
+    }
+
+    public RequestExecutor executor(AgentInstances<DockerService> agentInstances, PluginRequest pluginRequest) {
+        return new JobCompletionRequestExecutor(this, agentInstances, pluginRequest);
+    }
+
+    @Override
+    public String toString() {
+        return "JobCompletionRequest{" +
+                "elasticAgentId='" + elasticAgentId + '\'' +
+                ", jobIdentifier=" + jobIdentifier +
+                '}';
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/JobCompletionRequestExecutorTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/executors/JobCompletionRequestExecutorTest.java
@@ -1,0 +1,64 @@
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.executors;
+
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.*;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests.JobCompletionRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class JobCompletionRequestExecutorTest {
+    @Mock
+    private PluginRequest mockPluginRequest;
+    @Mock
+    private AgentInstances<DockerService> mockAgentInstances;
+
+    @Captor
+    private ArgumentCaptor<List<Agent>> agentsArgumentCaptor;
+
+    @Before
+    public void setUp(){
+        initMocks(this);
+    }
+
+    @Test
+    public void shouldTerminateElasticAgentOnJobCompletion() throws Exception {
+        JobIdentifier jobIdentifieær = new JobIdentifier(100L);
+        PluginSettings pluginSettings = new PluginSettings();
+        String elasticAgentId = "agent-1";
+        JobCompletionRequest request = new JobCompletionRequest(elasticAgentId, jobIdentifieær);
+        JobCompletionRequestExecutor executor = new JobCompletionRequestExecutor(request, mockAgentInstances, mockPluginRequest);
+
+        when(mockPluginRequest.getPluginSettings()).thenReturn(pluginSettings);
+
+        GoPluginApiResponse response = executor.execute();
+
+        InOrder inOrder = inOrder(mockPluginRequest, mockAgentInstances);
+
+        inOrder.verify(mockPluginRequest).getPluginSettings();
+        inOrder.verify(mockPluginRequest).disableAgents(agentsArgumentCaptor.capture());
+        List<Agent> agentsToDisabled = agentsArgumentCaptor.getValue();
+        assertEquals(1, agentsToDisabled.size());
+        assertEquals(elasticAgentId, agentsToDisabled.get(0).elasticAgentId());
+        inOrder.verify(mockAgentInstances).terminate(elasticAgentId, pluginSettings);
+        inOrder.verify(mockPluginRequest).deleteAgents(agentsArgumentCaptor.capture());
+        List<Agent> agentsToDelete = agentsArgumentCaptor.getValue();
+
+        assertEquals(agentsToDisabled, agentsToDelete);
+
+        assertEquals(200, response.responseCode());
+        assertTrue(response.responseBody().isEmpty());
+    }
+}

--- a/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/JobCompletionRequestTest.java
+++ b/src/test/java/cd/go/contrib/elasticagents/dockerswarm/elasticagent/requests/JobCompletionRequestTest.java
@@ -1,0 +1,38 @@
+package cd.go.contrib.elasticagents.dockerswarm.elasticagent.requests;
+
+import cd.go.contrib.elasticagents.dockerswarm.elasticagent.model.JobIdentifier;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+
+public class JobCompletionRequestTest {
+
+    @Test
+    public void shouldDeserializeFromJSON() throws Exception {
+
+        String json = "{\n" +
+                "  \"elastic_agent_id\": \"ea1\",\n" +
+                "  \"job_identifier\": {\n" +
+                "    \"pipeline_name\": \"test-pipeline\",\n" +
+                "    \"pipeline_counter\": 1,\n" +
+                "    \"pipeline_label\": \"Test Pipeline\",\n" +
+                "    \"stage_name\": \"test-stage\",\n" +
+                "    \"stage_counter\": \"1\",\n" +
+                "    \"job_name\": \"test-job\",\n" +
+                "    \"job_id\": 100\n" +
+                "  }\n" +
+                "}";
+
+        JobCompletionRequest request = JobCompletionRequest.fromJSON(json);
+
+        JobIdentifier expectedJobIdentifier = new JobIdentifier("test-pipeline", 1L, "Test Pipeline", "test-stage", "1", "test-job", 100L);
+        JobIdentifier actualJobIdentifier = request.jobIdentifier();
+
+        assertThat(actualJobIdentifier, is(expectedJobIdentifier));
+
+        assertThat(request.getElasticAgentId(), is("ea1"));
+    }
+
+
+}


### PR DESCRIPTION
* Support job-completion request to terminate the elastic agent immediately as soon as the job finishes

Logs:
```
2018-10-01 11:11:39,958 INFO  [qtp1863702030-22] DockerPlugin:73 - [Job Completion] Terminating elastic agent with id 2b1d53d1-c01d-4b76-8e21-d4099dab5e3f on job completion JobIdentifier{pipelineName='up42', pipelineCounter=13, pipelineLabel='13', stageName='up42_stage', stageCounter='1', jobName='up42_job', jobId=34}.
```